### PR TITLE
Eaton UPS does not need power status override

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -195,9 +195,6 @@ modules:
       - 1.3.6.1.4.1.534.1.3.9
       - 1.3.6.1.4.1.534.1.4.4.1.2
       - 1.3.6.1.4.1.534.1.12.2.1.2
-    overrides:
-      xupsBatteryAbmStatus:
-        type: EnumAsInfo
 
 # Morningstar Prostar Solar Controller
 #

--- a/snmp.yml
+++ b/snmp.yml
@@ -2534,7 +2534,7 @@ modules:
       help: Battery percent charge. - 1.3.6.1.4.1.534.1.2.4
     - name: xupsBatteryAbmStatus
       oid: 1.3.6.1.4.1.534.1.2.5
-      type: EnumAsInfo
+      type: gauge
       help: Gives the status of the Advanced Battery Management and Battery state;
         batteryFloating(3) status means that the charger is temporarily charging the
         battery to its float voltage; batteryResting(4) is the state when the battery


### PR DESCRIPTION
- Remove overrride of power status to EnumAsInfo

[SYS-99]